### PR TITLE
added GitLab API support

### DIFF
--- a/apis/gitlabapi/apis.go
+++ b/apis/gitlabapi/apis.go
@@ -1,0 +1,128 @@
+package gitlabapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/kubescape/go-git-url/apis"
+)
+
+const (
+	DEFAULT_HOST string = "gitlab.com"
+)
+
+type IGitLabAPI interface {
+	GetRepoTree(owner, repo, branch string, headers *Headers) (*Tree, error)
+	GetDefaultBranchName(owner, repo string, headers *Headers) (string, error)
+	GetLatestCommit(owner, repo, branch string, headers *Headers) (*Commit, error)
+}
+
+type GitLabAPI struct {
+	httpClient *http.Client
+}
+
+func NewGitLabAPI() *GitLabAPI { return &GitLabAPI{httpClient: &http.Client{}} }
+
+func (gl *GitLabAPI) GetRepoTree(owner, repo, branch string, headers *Headers) (*Tree, error) {
+	id := owner + "%2F" + repo
+
+	treeAPI := APIRepoTree(id, branch)
+	body, err := apis.HttpGet(gl.httpClient, treeAPI, headers.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var tree Tree
+	if err = json.Unmarshal([]byte(body), &tree); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body from '%s', reason: %s", treeAPI, err.Error())
+	}
+
+	return &tree, nil
+
+}
+
+func (gl *GitLabAPI) GetDefaultBranchName(owner, repo string, headers *Headers) (string, error) {
+
+	id := owner + "%2F" + repo
+	body, err := apis.HttpGet(gl.httpClient, APIMetadata(id), headers.ToMap())
+	if err != nil {
+		return "", err
+	}
+
+	var data gitlabDefaultBranchAPI
+	if err = json.Unmarshal([]byte(body), &data); err != nil {
+		return "", err
+	}
+
+	for i := range data {
+		if data[i].DefaultBranch {
+			return data[i].Name, nil
+		}
+	}
+
+	errAPI := errors.New("unable to find default branch from the GitLab API")
+	return "", errAPI
+}
+
+func (gl *GitLabAPI) GetLatestCommit(owner, repo, branch string, headers *Headers) (*Commit, error) {
+
+	id := owner + "%2F" + repo
+
+	body, err := apis.HttpGet(gl.httpClient, APILastCommitsOfBranch(id, branch), headers.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var data []Commit
+	err = json.Unmarshal([]byte(body), &data)
+	if err != nil {
+		return &data[0], err
+	}
+	return &data[0], nil
+}
+
+// APIRepoTree GitLab tree api
+// API Ref: https://docs.gitlab.com/ee/api/repositories.html
+func APIRepoTree(id, branch string) string {
+	return fmt.Sprintf("https://%s/api/v4/projects/%s/repository/tree?ref=%s", DEFAULT_HOST, id, branch)
+}
+
+// APIRaw GitLab : Get raw file from repository
+// API Ref: https://docs.gitlab.com/ee/api/repository_files.html#get-raw-file-from-repository
+// Example: https://gitlab.com/api/v4/projects/23383112/repository/files/app%2Findex.html/raw
+func APIRaw(owner, repo, branch, path string) string {
+	id := owner + "%2F" + repo
+	return fmt.Sprintf("https://%s/api/v4/projects/%s/repository/files/%s/raw", DEFAULT_HOST, id, path)
+}
+
+// APIDefaultBranch GitLab : Branch metadata; list repo branches
+// API Ref: https://docs.gitlab.com/ee/api/branches.html#list-repository-branches
+// Example: https://gitlab.com/api/v4/projects/nanuchi%2Fdeveloping-with-docker/repository/branches
+func APIMetadata(id string) string {
+	return fmt.Sprintf("https://%s/api/v4/projects/%s/repository/branches", DEFAULT_HOST, id)
+}
+
+// APILastCommits GitLab : List repository commits
+// API Ref: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
+// Example: https://gitlab.com/api/v4/projects/nanuchi%2Fdeveloping-with-docker/repository/commits
+func APILastCommits(id string) string {
+	return fmt.Sprintf("https://%s/api/v4/projects/%s/repository/commits", DEFAULT_HOST, id)
+}
+
+// TODO: These return list of commits, and we might want just a single latest commit. Pls check with this later:
+
+// APILastCommitsOfBranch GitLab : Last commits of specific branch
+// API Ref: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
+// Example: https://gitlab.com/api/v4/projects/nanuchi%2Fdeveloping-with-docker/repository/commits?ref_name=feature/k8s-in-hour
+func APILastCommitsOfBranch(id, branch string) string {
+	return fmt.Sprintf("%s?ref_name=%s", APILastCommits(id), branch)
+}
+
+// APILastCommitsOfPath GitLab : Last commits of specific branch & specified path
+// API Ref: https://docs.gitlab.com/ee/api/commits.html#list-repository-commits
+// Example: https://gitlab.com/api/v4/projects/nanuchi%2Fdeveloping-with-docker/repository/commits?ref_name=master&path=app/server.js
+func APILastCommitsOfPath(id, branch, path string) string {
+	return fmt.Sprintf("%s&path=%s", APILastCommitsOfBranch(id, branch), path)
+}

--- a/apis/gitlabapi/datastructures.go
+++ b/apis/gitlabapi/datastructures.go
@@ -1,0 +1,55 @@
+package gitlabapi
+
+import (
+	"time"
+)
+
+type ObjectType string
+
+const (
+	ObjectTypeDir  ObjectType = "tree"
+	ObjectTypeFile ObjectType = "blob"
+)
+
+type InnerTree struct {
+	ID   string     `json:"id"`
+	Name string 	`json:"name"`
+	Type ObjectType `json:"type"`
+	Path string     `json:"path"`
+	Mode string     `json:"mode"`
+}
+
+type Tree []InnerTree
+
+type gitlabDefaultBranchAPI []struct {
+	Name 				string 		`json:"name"`
+	Commit 				Commit 		`json:"commit"`
+	Merged 				bool 		`json:"merged"`
+	Protected 			bool 		`json:"protected"`
+	DevelopersCanPush	bool		`json:"developers_can_push"`
+	DevelopersCanMerge	bool		`json:"developers_can_merge"`
+	CanPush 			bool 		`json:"can_push"`
+	DefaultBranch 		bool 		`json:"default"`
+	WebURL 				string		`json:"web_url"`
+}
+
+type Headers struct {
+	Token string
+}
+
+// LatestCommit returned structure
+type Commit struct {
+	ID          	string          `json:"id"`
+	ShortID			string			`json:"short_id"`
+	CreatedAt		time.Time		`json:"created_at"`
+	Title 			string 			`json:"title"`
+	Message 		string 			`json:"message"`
+	AuthorName		string			`json:"author_name"`
+	AuthorEmail		string			`json:"author_email"`
+	AuthoredDate 	time.Time		`json:"authored_date"`
+	CommitterName	string			`json:"committer_name"`
+	CommitterEmail	string			`json:"committer_email"`
+	CommitterDate	time.Time		`json:"committed_date"`
+	WebURL 			string			`json:"web_url"`
+	ParentIDS       []string		`json:"parent_ids"`
+}

--- a/apis/gitlabapi/methods.go
+++ b/apis/gitlabapi/methods.go
@@ -1,0 +1,44 @@
+package gitlabapi
+
+import "fmt"
+
+// ListAll list all file/dir in repo tree
+func (t *Tree) ListAll() []string {
+	l := []string{}
+
+	for i := range *t {
+		l = append(l, (*t)[i].Path)
+	}
+	return l
+}
+
+// ListAllFiles list all files in repo tree
+func (t *Tree) ListAllFiles() []string {
+	l := []string{}
+	for i := range *t {
+		if (*t)[i].Type == ObjectTypeFile {
+			l = append(l, (*t)[i].Path)
+		}
+	}
+	return l
+}
+
+// ListAllDirs list all directories in repo tree
+func (t *Tree) ListAllDirs() []string {
+	l := []string{}
+	for i := range *t {
+		if (*t)[i].Type == ObjectTypeDir {
+			l = append(l, (*t)[i].Path)
+		}
+	}
+	return l
+}
+
+// ToMap convert headers to map[string]string
+func (h *Headers) ToMap() map[string]string {
+	m := make(map[string]string)
+	if h.Token != "" {
+		m["Authorization"] = fmt.Sprintf("Bearer %s", h.Token)
+	}
+	return m
+}

--- a/gitlabparser/v1/commit.go
+++ b/gitlabparser/v1/commit.go
@@ -1,0 +1,46 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/kubescape/go-git-url/apis"
+	"github.com/kubescape/go-git-url/apis/gitlabapi"
+)
+
+// ListAll list all directories and files in url tree
+func (gl *GitLabURL) GetLatestCommit() (*apis.Commit, error) {
+	if gl.GetHostName() == "" || gl.GetOwnerName() == "" || gl.GetRepoName() == "" {
+		return nil, fmt.Errorf("missing host/owner/repo")
+	}
+	if gl.GetBranchName() == "" {
+		if err := gl.SetDefaultBranchName(); err != nil {
+			return nil, fmt.Errorf("failed to get default branch. reason: %s", err.Error())
+		}
+	}
+
+	c, err := gl.gitLabAPI.GetLatestCommit(gl.GetOwnerName(), gl.GetRepoName(), gl.GetBranchName(), gl.headers())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest commit. reason: %s", err.Error())
+	}
+
+	return gitLabAPICommitToCommit(c), nil
+}
+
+func gitLabAPICommitToCommit(c *gitlabapi.Commit) *apis.Commit {
+	latestCommit := &apis.Commit{
+		SHA: c.ID,
+		Author: apis.Committer{
+			Name:  c.AuthorName,
+			Email: c.AuthorEmail,
+			Date:  c.AuthoredDate,
+		},
+		Committer: apis.Committer{
+			Name:  c.CommitterName,
+			Email: c.CommitterEmail,
+			Date:  c.CommitterDate,
+		},
+		Message: c.Message,
+	}
+
+	return latestCommit
+}

--- a/gitlabparser/v1/datastructures.go
+++ b/gitlabparser/v1/datastructures.go
@@ -1,11 +1,16 @@
 package v1
 
+import "github.com/kubescape/go-git-url/apis/gitlabapi"
+
 type GitLabURL struct {
-	host    string // default is github
+	host    string
 	owner   string // repo owner
 	repo    string // repo name
 	project string
 	branch  string
 	path    string
 	token   string // github token
+	isFile  bool
+
+	gitLabAPI gitlabapi.IGitLabAPI
 }

--- a/gitlabparser/v1/download.go
+++ b/gitlabparser/v1/download.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kubescape/go-git-url/apis/gitlabapi"
+)
+
+// DownloadAllFiles download files from git repo tree
+// return map of (url:file, url:error)
+func (gl *GitLabURL) DownloadAllFiles() (map[string][]byte, map[string]error) {
+
+	files, err := gl.ListFilesNames()
+	if err != nil {
+		return nil, map[string]error{"": err} // TODO - update error
+	}
+	return downloadFiles(gl.pathsToURLs(files))
+}
+
+// DownloadFilesWithExtension download files from git repo tree based on file extension
+// return map of (url:file, url:error)
+func (gl *GitLabURL) DownloadFilesWithExtension(filesExtensions []string) (map[string][]byte, map[string]error) {
+	files, err := gl.ListFilesNamesWithExtension(filesExtensions)
+	if err != nil {
+		return nil, map[string]error{"": err} // TODO - update error
+	}
+
+	return downloadFiles(gl.pathsToURLs(files))
+}
+
+// DownloadFiles download files from git repo. Call ListAllNames/ListFilesNamesWithExtention before calling this function
+// return map of (url:file, url:error)
+func downloadFiles(urls []string) (map[string][]byte, map[string]error) {
+	var errs map[string]error
+	files := map[string][]byte{}
+	for i := range urls {
+
+		file, err := downloadFile(urls[i])
+		if err != nil {
+			if errs == nil {
+				errs = map[string]error{}
+			}
+			errs[urls[i]] = err
+			continue
+		}
+		files[urls[i]] = file
+	}
+	return files, errs
+}
+
+// download single file
+func downloadFile(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || 301 < resp.StatusCode {
+		return nil, fmt.Errorf("failed to download file, url: '%s', status code: %s", url, resp.Status)
+	}
+	return streamToByte(resp.Body)
+}
+
+func streamToByte(stream io.Reader) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(stream); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (gl *GitLabURL) pathsToURLs(files []string) []string {
+	var rawURLs []string
+	for i := range files {
+		rawURLs = append(rawURLs, gitlabapi.APIRaw(gl.GetOwnerName(), gl.GetRepoName(), gl.GetBranchName(), files[i]))
+	}
+	return rawURLs
+}

--- a/gitlabparser/v1/parser.go
+++ b/gitlabparser/v1/parser.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/go-git-url/apis"
+	"github.com/kubescape/go-git-url/apis/gitlabapi"
 	giturl "github.com/whilp/git-urls"
 )
 
@@ -16,6 +17,7 @@ const HOST = "gitlab.com"
 func NewGitLabParser() *GitLabURL {
 
 	return &GitLabURL{
+		gitLabAPI: gitlabapi.NewGitLabAPI(),
 		host:  HOST,
 		token: os.Getenv("GITLAB_TOKEN"),
 	}
@@ -90,7 +92,7 @@ func (gl *GitLabURL) Parse(fullURL string) error {
 
 	// is file or dir
 	switch splittedRepo[index] {
-	case "blob", "tree", "raw":
+	case "blob", "tree":
 		index++
 	}
 
@@ -107,4 +109,18 @@ func (gl *GitLabURL) Parse(fullURL string) error {
 	gl.path = strings.Join(splittedRepo[index:], "/")
 
 	return nil
+}
+
+// Set the default brach of the repo
+func (gl *GitLabURL) SetDefaultBranchName() error {
+	branch, err := gl.gitLabAPI.GetDefaultBranchName(gl.GetOwnerName(), gl.GetRepoName(), gl.headers())
+	if err != nil {
+		return err
+	}
+	gl.branch = branch
+	return nil
+}
+
+func (gl *GitLabURL) headers() *gitlabapi.Headers {
+	return &gitlabapi.Headers{Token: gl.GetToken()}
 }

--- a/gitlabparser/v1/tree.go
+++ b/gitlabparser/v1/tree.go
@@ -1,0 +1,98 @@
+package v1
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/go-git-url/apis/gitlabapi"
+	"k8s.io/utils/strings/slices"
+)
+
+// ListAll list all directories and files in url tree
+func (gl *GitLabURL) GetTree() (*gitlabapi.Tree, error) {
+
+	if gl.isFile {
+		return &gitlabapi.Tree{
+			gitlabapi.InnerTree{
+				Path: gl.GetPath(),
+				Type: gitlabapi.ObjectTypeFile,
+			},
+		}, nil
+	}
+
+	if gl.GetHostName() == "" || gl.GetOwnerName() == "" || gl.GetRepoName() == "" {
+		return nil, fmt.Errorf("missing host/owner/repo")
+	}
+
+	if gl.GetBranchName() == "" {
+		if err := gl.SetDefaultBranchName(); err != nil {
+			return nil, fmt.Errorf("failed to get default branch. reason: %s", err.Error())
+		}
+	}
+	
+	repoTree, err := gl.gitLabAPI.GetRepoTree(gl.GetOwnerName(), gl.GetRepoName(), gl.GetBranchName(), gl.headers())
+	if err != nil {
+		return repoTree, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree, nil
+}
+
+// ListAllNames list all directories and files in url tree
+func (gl *GitLabURL) ListAllNames() ([]string, error) {
+	repoTree, err := gl.GetTree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+	return repoTree.ListAll(), nil
+}
+
+// ListDirsNames list all directories in url tree
+func (gl *GitLabURL) ListDirsNames() ([]string, error) {
+	repoTree, err := gl.GetTree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree.ListAllDirs(), nil
+}
+
+
+// ListAll list all files in url tree
+func (gl *GitLabURL) ListFilesNames() ([]string, error) {
+	repoTree, err := gl.GetTree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree.ListAllFiles(), nil
+}
+
+// ListFilesNamesWithExtension list all files in path with the desired extension
+func (gl *GitLabURL) ListFilesNamesWithExtension(filesExtensions []string) ([]string, error) {
+
+	fileNames, err := gl.ListFilesNames()
+	if err != nil {
+		return []string{}, err
+	}
+	if len(fileNames) == 0 {
+		return fileNames, nil
+	}
+
+	var files []string
+	for _, path := range fileNames {
+		if gl.GetPath() != "" && !strings.HasPrefix(path, gl.GetPath()) {
+			continue
+		}
+		if slices.Contains(filesExtensions, getFileExtension(path)) {
+			files = append(files, path)
+		}
+
+	}
+	return files, nil
+}
+
+func getFileExtension(path string) string {
+	return strings.TrimPrefix(filepath.Ext(path), ".")
+}

--- a/init.go
+++ b/init.go
@@ -6,6 +6,7 @@ import (
 	giturl "github.com/whilp/git-urls"
 
 	"github.com/kubescape/go-git-url/apis/githubapi"
+	"github.com/kubescape/go-git-url/apis/gitlabapi"
 	azureparserv1 "github.com/kubescape/go-git-url/azureparser/v1"
 	githubparserv1 "github.com/kubescape/go-git-url/githubparser/v1"
 	gitlabparserv1 "github.com/kubescape/go-git-url/gitlabparser/v1"
@@ -40,6 +41,8 @@ func NewGitAPI(fullURL string) (IGitAPI, error) {
 	switch hostUrl {
 	case githubapi.DEFAULT_HOST, githubapi.RAW_HOST:
 		return githubparserv1.NewGitHubParserWithURL(fullURL)
+	case gitlabapi.DEFAULT_HOST:
+		return gitlabparserv1.NewGitLabParserWithURL(fullURL)
 	default:
 		return nil, fmt.Errorf("repository host '%s' not supported", hostUrl)
 	}

--- a/interface.go
+++ b/interface.go
@@ -13,6 +13,7 @@ type IGitURL interface {
 	SetPath(string)
 	SetRepoName(string)
 
+	GetHostName() string
 	GetProvider() string
 	GetBranchName() string
 	GetOwnerName() string


### PR DESCRIPTION
Signed-off-by: Anubhav Gupta <mail.anubhav06@gmail.com>
fixes [#953](https://github.com/kubescape/kubescape/issues/953)

**Added GitLab API support**
Now, users can scan a remote repository which is hosted on `GitLab` as well. (Be it private/public)
Format for scanning: `kubescape scan https://gitlab.com/<username>/<repo>`

**NOTE:** The `ListAllNames()`/`ListFilesNames()` method does not list the files present in subdirectories. It only lists the files present in the top most directory. 
This is because of GitLab's API. GitLab does not offer any API to list all the files present in sub-directories as well. It provides an API for "[Listing Repository Tree](https://docs.gitlab.com/ee/api/repositories.html#list-repository-tree)" which is what I have implemented. This API shows the directories, sub-directories, and files present in the top-most directory.
(Although I don't think this would have any affect on KubeScape scanning the remote repo, a confirmation on this would be appreciated)

**GitLab Public Repo:**
![Screenshot 2022-12-11 205452](https://user-images.githubusercontent.com/43821031/206914225-9d769145-cdde-4995-9780-111db5794ddd.png)  
  
**GitLab Private Repo (when no token is provided):**
![Screenshot 2022-12-11 205600](https://user-images.githubusercontent.com/43821031/206914245-9e3809ff-a65e-491e-992a-46a54f4ea43a.png)    

  
