### PR TITLE
3 [BUG🪲] Missing `GetHostName()` method in `IGitURL` interface

### DIFF
--- a/interface.go
+++ b/interface.go
@@ -19,6 +19,7 @@ type IGitURL interface {
 	GetPath() string
 	GetRepoName() string
 	GetHttpCloneURL() string
+	GetHostName() string
 
 	// parse url
 	Parse(fullURL string) error


### PR DESCRIPTION
Requested changes made successfully