### PR TITLE
added Azure API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,13 @@ func main() {
 ### Supported APIs
 
 * GitHub
+> It is recommended to use a [GitHub token](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). Set the GitHub token in the `GITHUB_TOKEN` env
 
-> It is recommended to use a [github token](https://docs.github.com/en/enterprise-server@3.4/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). Set the github token in the `GITHUB_TOKEN` env
+* GitLab
+> It is recommended to use a [GitLab token](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#create-a-personal-access-token). Set the GitLab token in the `GITLAB_TOKEN` env
+
+* Azure
+> It is recommended to use a [Azure token](https://learn.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops&tabs=Windows#create-a-pat). Set the Azure token in the `AZURE_TOKEN` env
 
 ### List files and directories
 ```go

--- a/apis/azureapi/apis.go
+++ b/apis/azureapi/apis.go
@@ -60,7 +60,7 @@ func (az *AzureAPI) GetDefaultBranchName(owner, project, repo string, headers *H
 		}
 	}
 
-	errAPI := errors.New("unable to find default branch from the GitLab API")
+	errAPI := errors.New("unable to find default branch from the Azure API")
 	return "", errAPI
 }
 

--- a/apis/azureapi/apis.go
+++ b/apis/azureapi/apis.go
@@ -1,0 +1,139 @@
+package azureapi
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/kubescape/go-git-url/apis"
+)
+
+const (
+	DEFAULT_HOST string = "azure.com"
+	DEV_HOST     string = "dev.azure.com"
+)
+
+type IAzureAPI interface {
+	GetRepoTree(owner, project, repo, branch string, headers *Headers) (*Tree, error)
+	GetDefaultBranchName(owner, project, repo string, headers *Headers) (string, error)
+	GetLatestCommit(owner, project, repo, branch string, headers *Headers) (*Commit, error)
+}
+
+type AzureAPI struct {
+	httpClient *http.Client
+}
+
+func NewAzureAPI() *AzureAPI { return &AzureAPI{httpClient: &http.Client{}} }
+
+func (az *AzureAPI) GetRepoTree(owner, project, repo, branch string, headers *Headers) (*Tree, error) {
+	treeAPI := APIRepoTree(owner, project, repo, branch)
+	body, err := apis.HttpGet(az.httpClient, treeAPI, headers.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var tree Tree
+	if err = json.Unmarshal([]byte(body), &tree); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal response body from '%s', reason: %s", treeAPI, err.Error())
+	}
+
+	return &tree, nil
+
+}
+
+func (az *AzureAPI) GetDefaultBranchName(owner, project, repo string, headers *Headers) (string, error) {
+
+	body, err := apis.HttpGet(az.httpClient, APIMetadata(owner, project, repo), headers.ToMap())
+	if err != nil {
+		return "", err
+	}
+
+	var data azureDefaultBranchAPI
+	err = json.Unmarshal([]byte(body), &data)
+	if err != nil {
+		return "", err
+	}
+	for i := range data.BranchValue {
+		if data.BranchValue[i].IsBaseVersion {
+			return data.BranchValue[i].Name, nil
+		}
+	}
+
+	errAPI := errors.New("unable to find default branch from the GitLab API")
+	return "", errAPI
+}
+
+func (az *AzureAPI) GetLatestCommit(owner, project, repo, branch string, headers *Headers) (*Commit, error) {
+
+	body, err := apis.HttpGet(az.httpClient, APILastCommitsOfBranch(owner, project, repo, branch), headers.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var data Commit
+	err = json.Unmarshal([]byte(body), &data)
+	if err != nil {
+		return &data, err
+	}
+	return &data, nil
+}
+
+// Get latest commit data of path/file
+func (az *AzureAPI) GetFileLatestCommit(owner, project, repo, branch, fullPath string, headers *Headers) ([]Commit, error) {
+
+	body, err := apis.HttpGet(az.httpClient, APILastCommitsOfPath(owner, project, repo, branch, fullPath), headers.ToMap())
+	if err != nil {
+		return nil, err
+	}
+
+	var data []Commit
+	err = json.Unmarshal([]byte(body), &data)
+	if err != nil {
+		return data, err
+	}
+	return data, nil
+}
+
+// APIRepoTree Azure tree api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/items/list?view=azure-devops-rest-7.0&tabs=HTTP#full-recursion-and-with-content-metadata
+// Example: https://dev.azure.com/anubhav06/testing/_apis/git/repositories/testing/items?recursionLevel=Full&versionDescriptor.version=dev&api-version=5.1
+func APIRepoTree(owner, project, repo, branch string) string {
+	return fmt.Sprintf("https://dev.%s/%s/%s/_apis/git/repositories/%s/items?recursionLevel=Full&versionDescriptor.version=%s&api-version=5.1", DEFAULT_HOST, owner, project, repo, branch)
+}
+
+// APIRaw Azure raw file api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/build/source-providers/get-file-contents?view=azure-devops-rest-7.0
+// https://stackoverflow.com/questions/56281152/how-to-get-a-link-to-a-file-from-a-vso-repo/56283730#56283730
+// Example: https://dev.azure.com/anubhav06/k8s-example/_apis/sourceProviders/tfsgit/filecontents?&repository=k8s-example&commitOrBranch=master&path=/volumes/cephfs/cephfs.yaml&api-version=7.0
+func APIRaw(owner, project, repo, branch, path string) string {
+	return fmt.Sprintf("https://dev.%s/%s/%s/_apis/sourceProviders/tfsgit/filecontents?&repository=%s&commitOrBranch=%s&path=%s", DEFAULT_HOST, owner, project, repo, branch, path)
+}
+
+// APIDefaultBranch Azure repo metadata api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/stats/list?view=azure-devops-rest-4.1&tabs=HTTP
+// Example: https://dev.azure.com/anubhav06/k8s-example/_apis/git/repositories/k8s-example/stats/branches?api-version=4.1
+func APIMetadata(owner, project, repo string) string {
+	return fmt.Sprintf("https://dev.%s/%s/%s/_apis/git/repositories/%s/stats/branches?api-version=4.1", DEFAULT_HOST, owner, project, repo)
+}
+
+// APILastCommits Azure last commit api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commits?view=azure-devops-rest-4.1&tabs=HTTP
+// Example: https://dev.azure.com/anubhav06/k8s-example/_apis/git/repositories/k8s-example/commits?searchCriteria.$top=1&api-version=4.1
+func APILastCommits(owner, project, repo string) string {
+	return fmt.Sprintf("https://dev.%s/%s/%s/_apis/git/repositories/%s/commits?searchCriteria.$top=1", DEFAULT_HOST, owner, project, repo)
+}
+
+// APILastCommitsOfBranch Azure last commit of specific branch api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commits?view=azure-devops-rest-4.1&tabs=HTTP
+// Example: https://dev.azure.com/anubhav06/testing/_apis/git/repositories/testing/commits?searchCriteria.$top=1&searchCriteria.itemVersion.version=dev
+func APILastCommitsOfBranch(owner, project, repo, branch string) string {
+	return fmt.Sprintf("%s&searchCriteria.itemVersion.version=%s", APILastCommits(owner, project, repo), branch)
+}
+
+// APILastCommitsOfPath Azure last commit of specific branch api
+// API Ref: https://learn.microsoft.com/en-us/rest/api/azure/devops/git/commits/get-commits?view=azure-devops-rest-4.1&tabs=HTTP
+// Example: https://dev.azure.com/anubhav06/k8s-example/_apis/git/repositories/k8s-example/commits?searchCriteria.$top=1&searchCriteria.itemVersion.version=master&searchCriteria.itemPath=volumes/storageos/storageos-pod.yaml
+func APILastCommitsOfPath(owner, project, repo, branch, path string) string {
+	return fmt.Sprintf("%s&searchCriteria.itemPath=%s", APILastCommitsOfBranch(owner, project, repo, branch), path)
+}

--- a/apis/azureapi/datastructures.go
+++ b/apis/azureapi/datastructures.go
@@ -1,0 +1,93 @@
+package azureapi
+
+import (
+	"time"
+)
+
+type ObjectType string
+
+const (
+	ObjectTypeDir  ObjectType = "tree"
+	ObjectTypeFile ObjectType = "blob"
+)
+
+type InnerTree struct {
+	ObjectID      string     `json:"objectId"`
+	GitObjectType ObjectType `json:"gitObjectType"`
+	CommitID      string     `json:"commitId"`
+	Path          string     `json:"path"`
+	IsFolder      bool       `json:"isFolder"`
+	Url           string     `json:"url"`
+}
+
+type Tree struct {
+	Count     int         `json:"count"`
+	InnerTree []InnerTree `json:"value"`
+}
+
+type CommitsMetadata struct {
+	TreeID   string `json:"treeId"`
+	CommitID string `json:"commitId"`
+	Author   struct {
+		Name  string    `json:"name"`
+		Email string    `json:"email"`
+		Date  time.Time `json:"date"`
+	} `json:"author"`
+	Committer struct {
+		Name  string    `json:"name"`
+		Email string    `json:"email"`
+		Date  time.Time `json:"date"`
+	} `json:"committer"`
+	Comment string   `json:"comment"`
+	Parents []string `json:"parents"`
+	URL     string   `json:"url"`
+}
+
+type BranchValue struct {
+	Commit        CommitsMetadata `json:"commit"`
+	Name          string          `json:"name"`
+	AheadCount    int             `json:"aheadCount"`
+	BehindCount   int             `json:"behindCount"`
+	IsBaseVersion bool            `json:"isBaseVersion"`
+}
+
+type azureDefaultBranchAPI struct {
+	Count       int           `json:"count"`
+	BranchValue []BranchValue `json:"value"`
+}
+
+type Headers struct {
+	Token string
+}
+
+type CommitsValue struct {
+	CommitID string `json:"commitId"`
+	Author   struct {
+		Name  string    `json:"name"`
+		Email string    `json:"email"`
+		Date  time.Time `json:"date"`
+	} `json:"author"`
+	Committer struct {
+		Name  string    `json:"name"`
+		Email string    `json:"email"`
+		Date  time.Time `json:"date"`
+	} `json:"committer"`
+	Comment      string `json:"comment"`
+	ChangeCounts struct {
+		Add    int `json:"add"`
+		Edit   int `json:"edit"`
+		Delete int `json:"delete"`
+	} `json:"changeCounts"`
+	Changes []struct {
+		SourceServerItem string `json:"sourceServerItem"`
+		ChangeType       string `json:"changeType"`
+	} `json:"changes"`
+	URL       string `json:"url"`
+	RemoteURL string `json:"remoteUrl"`
+}
+
+// LatestCommit returned structure
+type Commit struct {
+	Count        int            `json:"count"`
+	CommitsValue []CommitsValue `json:"value"`
+}

--- a/apis/azureapi/methods.go
+++ b/apis/azureapi/methods.go
@@ -1,0 +1,49 @@
+package azureapi
+
+import (
+	b64 "encoding/base64"
+	"fmt"
+)
+
+// ListAll list all file/dir in repo tree
+func (t *Tree) ListAll() []string {
+	l := []string{}
+	for i := range t.InnerTree {
+		l = append(l, t.InnerTree[i].Path)
+	}
+	return l
+}
+
+// ListAllFiles list all files in repo tree
+func (t *Tree) ListAllFiles() []string {
+	l := []string{}
+	for i := range t.InnerTree {
+		if t.InnerTree[i].GitObjectType == ObjectTypeFile {
+			l = append(l, t.InnerTree[i].Path)
+		}
+	}
+	return l
+}
+
+// ListAllDirs list all directories in repo tree
+func (t *Tree) ListAllDirs() []string {
+	l := []string{}
+	for i := range t.InnerTree {
+		if t.InnerTree[i].GitObjectType == ObjectTypeDir {
+			l = append(l, t.InnerTree[i].Path)
+		}
+	}
+	return l
+}
+
+// ToMap convert headers to map[string]string
+func (h *Headers) ToMap() map[string]string {
+	m := make(map[string]string)
+
+	if h.Token != "" {
+		fToken := ":" + h.Token
+		sEnc := b64.StdEncoding.EncodeToString([]byte(fToken))
+		m["Authorization"] = fmt.Sprintf("Basic %s", sEnc)
+	}
+	return m
+}

--- a/apis/azureapi/methods_test.go
+++ b/apis/azureapi/methods_test.go
@@ -1,0 +1,22 @@
+package azureapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAll(t *testing.T) {
+	tree, _ := NewMockAzureAPI().GetRepoTree("anubhav06", "testing", "testing", "master", nil)
+	assert.Equal(t, 12, len(tree.ListAll()))
+}	
+
+func TestListAllFiles(t *testing.T) {
+	tree, _ := NewMockAzureAPI().GetRepoTree("anubhav06", "testing", "testing", "master", nil)
+	assert.Equal(t, 11, len(tree.ListAllFiles()))
+}
+
+func TestListAllDirs(t *testing.T) {
+	tree, _ := NewMockAzureAPI().GetRepoTree("anubhav06", "testing", "testing", "master", nil)
+	assert.Equal(t, 1, len(tree.ListAllDirs()))
+}

--- a/apis/azureapi/mockapis.go
+++ b/apis/azureapi/mockapis.go
@@ -1,0 +1,37 @@
+package azureapi
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var mockTreeUrl = `{ "count": 12, "value": [ { "objectId": "3838adf7667bcec12a8bd0b868e5ce18e4476815", "gitObjectType": "tree", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/", "isFolder": true, "url": "https://dev.azure.com/anubhav06/2773a1e0-3a09-4b3c-962d-31b884fe58c4/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items?path=%2F&versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "62c893550adb53d3a8fc29a1584ff831cb829062", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/.gitignore", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//.gitignore?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "9172c84f0c2141833cc3b0ed512f94e36e789aa0", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/README.md", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//README.md?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "ea6048a012f2a69a09660cea3138ac64db49c021", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/postgres-pod.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//postgres-pod.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "2f16bbce9eee40d071aed4bd9a0e601fc99b9216", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/postgres-service.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//postgres-service.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "a0af8b4a8fe692a4526a159e851a7bf7efde1c69", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/redis-pod.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//redis-pod.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "2bab8621dfb18f40b5487df40aaef3921e61849b", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/redis-service.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//redis-service.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "009faa3b128a0375772f4914b74419da3abd079b", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/result-app-pod.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//result-app-pod.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "523ad3a6ac0419d335ffa3269bc4e057d06fe63e", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/result-app-service.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//result-app-service.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "bcced3583f5c8a208ecf7149a195ad21d17083aa", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/voting-app-pod.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//voting-app-pod.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "d055a91baadb058e7ed211705f5e4b8f42127215", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/voting-app-service.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//voting-app-service.yml?versionType=Branch&version=dev&versionOptions=None" }, { "objectId": "ea912ca1e7a8bf4bd4b149d68f97f692c3a11092", "gitObjectType": "blob", "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "path": "/worker-app-pod.yml", "url": "https://dev.azure.com/anubhav06/testing/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/items//worker-app-pod.yml?versionType=Branch&version=dev&versionOptions=None" } ] }`
+var mockLastCommit = `{ "count": 1, "value": [ { "commitId": "8cb368a261285f7d5129109f9bb3918de1999449", "author": { "name": "Anubhav Gupta", "email": null, "date": "2022-12-22T12:58:10Z" }, "committer": { "name": "Anubhav Gupta", "email": null, "date": "2022-12-22T12:58:10Z" }, "comment": "Updated README.md", "changeCounts": { "Add": 0, "Edit": 1, "Delete": 0 }, "url": "https://dev.azure.com/anubhav06/2773a1e0-3a09-4b3c-962d-31b884fe58c4/_apis/git/repositories/e4a1a3d3-c2e7-4781-89af-2dff3a8412f6/commits/8cb368a261285f7d5129109f9bb3918de1999449", "remoteUrl": "https://dev.azure.com/anubhav06/testing/_git/testing/commit/8cb368a261285f7d5129109f9bb3918de1999449" } ] }`
+
+type MockAzureAPI struct {
+}
+
+func NewMockAzureAPI() *MockAzureAPI { return &MockAzureAPI{} }
+
+func (az *MockAzureAPI) GetRepoTree(owner, project, repo, branch string, headers *Headers) (*Tree, error) {
+	t := Tree{}
+	switch fmt.Sprintf("%s/%s/_git/%s", owner, project, repo) {
+	case "anubhav06/testing/_git/testing":
+		json.Unmarshal([]byte(mockTreeUrl), &t)
+	}
+	return &t, nil
+}
+
+func (az MockAzureAPI) GetDefaultBranchName(owner, project, repo string, headers *Headers) (string, error) {
+	return "master", nil
+}
+
+func (az MockAzureAPI) GetLatestCommit(owner, project, repo, branch string, headers *Headers) (*Commit, error) {
+
+	var data Commit
+
+	if err := json.Unmarshal([]byte(mockLastCommit), &data); err != nil {
+		return &data, err
+	}
+	return &data, nil
+}

--- a/azureparser/v1/commit.go
+++ b/azureparser/v1/commit.go
@@ -1,0 +1,46 @@
+package v1
+
+import (
+	"fmt"
+
+	"github.com/kubescape/go-git-url/apis"
+	"github.com/kubescape/go-git-url/apis/azureapi"
+)
+
+// ListAll list all directories and files in url tree
+func (az *AzureURL) GetLatestCommit() (*apis.Commit, error) {
+	if az.GetHostName() == "" || az.GetOwnerName() == "" || az.GetProjectName() == "" || az.GetRepoName() == "" {
+		return nil, fmt.Errorf("missing host/owner/project/repo")
+	}
+	if az.GetBranchName() == "" {
+		if err := az.SetDefaultBranchName(); err != nil {
+			return nil, fmt.Errorf("failed to get default branch. reason: %s", err.Error())
+		}
+	}
+
+	c, err := az.azureAPI.GetLatestCommit(az.GetOwnerName(), az.GetProjectName(), az.GetRepoName(), az.GetBranchName(), az.headers())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get latest commit. reason: %s", err.Error())
+	}
+
+	return azureAPICommitToCommit(c), nil
+}
+
+func azureAPICommitToCommit(c *azureapi.Commit) *apis.Commit {
+	latestCommit := &apis.Commit{
+		SHA: c.CommitsValue[0].CommitID,
+		Author: apis.Committer{
+			Name:  c.CommitsValue[0].Author.Name,
+			Email: c.CommitsValue[0].Author.Email,
+			Date:  c.CommitsValue[0].Author.Date,
+		},
+		Committer: apis.Committer{
+			Name:  c.CommitsValue[0].Committer.Name,
+			Email: c.CommitsValue[0].Committer.Email,
+			Date:  c.CommitsValue[0].Committer.Date,
+		},
+		Message: c.CommitsValue[0].Comment,
+	}
+
+	return latestCommit
+}

--- a/azureparser/v1/commit_test.go
+++ b/azureparser/v1/commit_test.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLatestCommit(t *testing.T) {
+	{
+		az, err := NewAzureParserWithURL(urlA)
+		assert.NoError(t, err)
+		latestCommit, err := az.GetLatestCommit()
+		assert.NoError(t, err)
+		assert.Equal(t, "4502b9b51ee3ac1ea649bacfa0f48ebdeab05f4a", latestCommit.SHA)
+		assert.Equal(t, "GitHub", latestCommit.Committer.Name)
+		assert.Equal(t, "", latestCommit.Committer.Email)
+	}
+}

--- a/azureparser/v1/datastructures.go
+++ b/azureparser/v1/datastructures.go
@@ -1,15 +1,19 @@
 package v1
 
+import "github.com/kubescape/go-git-url/apis/azureapi"
+
 type AzureURL struct {
-	host     string // default is github
+	host     string
 	owner    string // repo owner
 	repo     string // repo name
 	project  string
 	branch   string
 	tag      string
 	path     string
-	token    string // github token
+	token    string // azure token
 	isFile   bool   // is the URL is pointing to a file or not
-	username string
-	password string
+	// username string
+	// password string
+
+	azureAPI azureapi.IAzureAPI
 }

--- a/azureparser/v1/download.go
+++ b/azureparser/v1/download.go
@@ -1,0 +1,81 @@
+package v1
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/kubescape/go-git-url/apis/azureapi"
+)
+
+// DownloadAllFiles download files from git repo tree
+// return map of (url:file, url:error)
+func (az *AzureURL) DownloadAllFiles() (map[string][]byte, map[string]error) {
+
+	files, err := az.ListFilesNames()
+	if err != nil {
+		return nil, map[string]error{"": err} // TODO - update error
+	}
+	return downloadFiles(az.pathsToURLs(files))
+}
+
+// DownloadFilesWithExtension download files from git repo tree based on file extension
+// return map of (url:file, url:error)
+func (az *AzureURL) DownloadFilesWithExtension(filesExtensions []string) (map[string][]byte, map[string]error) {
+	files, err := az.ListFilesNamesWithExtension(filesExtensions)
+	if err != nil {
+		return nil, map[string]error{"": err} // TODO - update error
+	}
+
+	return downloadFiles(az.pathsToURLs(files))
+}
+
+// DownloadFiles download files from git repo. Call ListAllNames/ListFilesNamesWithExtention before calling this function
+// return map of (url:file, url:error)
+func downloadFiles(urls []string) (map[string][]byte, map[string]error) {
+	var errs map[string]error
+	files := map[string][]byte{}
+	for i := range urls {
+
+		file, err := downloadFile(urls[i])
+		if err != nil {
+			if errs == nil {
+				errs = map[string]error{}
+			}
+			errs[urls[i]] = err
+			continue
+		}
+		files[urls[i]] = file
+	}
+	return files, errs
+}
+
+// download single file
+func downloadFile(url string) ([]byte, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || 301 < resp.StatusCode {
+		return nil, fmt.Errorf("failed to download file, url: '%s', status code: %s", url, resp.Status)
+	}
+	return streamToByte(resp.Body)
+}
+
+func streamToByte(stream io.Reader) ([]byte, error) {
+	buf := new(bytes.Buffer)
+	if _, err := buf.ReadFrom(stream); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+func (az *AzureURL) pathsToURLs(files []string) []string {
+	var rawURLs []string
+	for i := range files {
+		rawURLs = append(rawURLs, azureapi.APIRaw(az.GetOwnerName(), az.GetProjectName(), az.GetRepoName(), az.GetBranchName(), files[i]))
+	}
+	return rawURLs
+}

--- a/azureparser/v1/parser.go
+++ b/azureparser/v1/parser.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/kubescape/go-git-url/apis"
+	"github.com/kubescape/go-git-url/apis/azureapi"
 	giturl "github.com/whilp/git-urls"
 )
 
@@ -14,15 +15,17 @@ const HOST = "azure.com"
 const HOST_DEV = "dev.azure.com"
 const HOST_PROD = "prod.azure.com"
 
-// NewGitHubParser empty instance of a github parser
+// NewAzureParser empty instance of a azure parser
 func NewAzureParser() *AzureURL {
 
 	return &AzureURL{
-		token: os.Getenv("AZURE_TOKEN"),
+		azureAPI: azureapi.NewAzureAPI(),
+		host:     HOST,
+		token:    os.Getenv("AZURE_TOKEN"),
 	}
 }
 
-// NewGitHubParserWithURL parsed instance of a github parser
+// NewAzureParserWithURL parsed instance of a azure parser
 func NewAzureParserWithURL(fullURL string) (*AzureURL, error) {
 	az := NewAzureParser()
 
@@ -119,4 +122,20 @@ func (az *AzureURL) parseHostHTTP(parsedURL *url.URL) error {
 	}
 
 	return nil
+}
+
+// Set the default brach of the repo
+func (az *AzureURL) SetDefaultBranchName() error {
+
+	branch, err := az.azureAPI.GetDefaultBranchName(az.GetOwnerName(), az.GetProjectName(), az.GetRepoName(), az.headers())
+
+	if err != nil {
+		return err
+	}
+	az.branch = branch
+	return nil
+}
+
+func (az *AzureURL) headers() *azureapi.Headers {
+	return &azureapi.Headers{Token: az.GetToken()}
 }

--- a/azureparser/v1/parser_test.go
+++ b/azureparser/v1/parser_test.go
@@ -11,9 +11,11 @@ var (
 	urlB = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=/rules-tests/alert-rw-hostpath/deployment/expected.json"
 	urlC = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=/scripts&version=GBdev&_a=contents"
 	urlD = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=/scripts&version=GTv1.0.1&_a=contents"
+	urlE = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=%2F&version=GBdev"
+	urlF = "https://dwertent@dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public"
 )
 
-func TestNewGitHubParserWithURL(t *testing.T) {
+func TestNewAzureParserWithURL(t *testing.T) {
 	{
 		az, err := NewAzureParserWithURL(urlA)
 		assert.NoError(t, err)
@@ -59,5 +61,27 @@ func TestNewGitHubParserWithURL(t *testing.T) {
 		assert.Equal(t, "v1.0.1", az.GetTag())
 		assert.Equal(t, "", az.GetBranchName())
 		assert.Equal(t, "/scripts", az.GetPath())
+	}
+}
+
+
+func TestSetDefaultBranch(t *testing.T) {
+	{
+		az, err := NewAzureParserWithURL(urlA)
+		assert.NoError(t, err)
+		assert.NoError(t, az.SetDefaultBranchName())
+		assert.Equal(t, "master", az.GetBranchName())
+	}
+	{
+		az, err := NewAzureParserWithURL(urlE)
+		assert.NoError(t, err)
+		assert.NoError(t, az.SetDefaultBranchName())
+		assert.Equal(t, "master", az.GetBranchName())
+	}
+	{
+		az, err := NewAzureParserWithURL(urlF)
+		assert.NoError(t, err)
+		assert.NoError(t, az.SetDefaultBranchName())
+		assert.Equal(t, "master", az.GetBranchName())
 	}
 }

--- a/azureparser/v1/tree.go
+++ b/azureparser/v1/tree.go
@@ -1,0 +1,102 @@
+package v1
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/kubescape/go-git-url/apis/azureapi"
+	"k8s.io/utils/strings/slices"
+)
+
+// ListAll list all directories and files in url tree
+func (az *AzureURL) GetTree() (*azureapi.Tree, error) {
+
+	if az.isFile {
+		return &azureapi.Tree{
+			InnerTree: []azureapi.InnerTree{
+				{
+					Path:          az.GetPath(),
+					GitObjectType: azureapi.ObjectTypeFile,
+				},
+			},
+		}, nil
+	}
+
+	if az.GetHostName() == "" || az.GetOwnerName() == "" || az.GetProjectName() == "" || az.GetRepoName() == "" {
+		return nil, fmt.Errorf("missing host/owner/project/repo")
+	}
+
+	if az.GetBranchName() == "" {
+		if err := az.SetDefaultBranchName(); err != nil {
+			return nil, fmt.Errorf("failed to get default branch. reason: %s", err.Error())
+		}
+	}
+
+	repoTree, err := az.azureAPI.GetRepoTree(az.GetOwnerName(), az.GetProjectName(), az.GetRepoName(), az.GetBranchName(), az.headers())
+	if err != nil {
+		return repoTree, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree, nil
+}
+
+// ListAllNames list all directories and files in url tree
+func (az *AzureURL) ListAllNames() ([]string, error) {
+
+	repoTree, err := az.GetTree()
+
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree.ListAll(), nil
+}
+
+// ListDirsNames list all directories in url tree
+func (az *AzureURL) ListDirsNames() ([]string, error) {
+	repoTree, err := az.GetTree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree.ListAllDirs(), nil
+}
+
+// ListAll list all files in url tree
+func (az *AzureURL) ListFilesNames() ([]string, error) {
+	repoTree, err := az.GetTree()
+	if err != nil {
+		return []string{}, fmt.Errorf("failed to get repo tree. reason: %s", err.Error())
+	}
+
+	return repoTree.ListAllFiles(), nil
+}
+
+// ListFilesNamesWithExtension list all files in path with the desired extension
+func (az *AzureURL) ListFilesNamesWithExtension(filesExtensions []string) ([]string, error) {
+
+	fileNames, err := az.ListFilesNames()
+	if err != nil {
+		return []string{}, err
+	}
+	if len(fileNames) == 0 {
+		return fileNames, nil
+	}
+
+	var files []string
+	for _, path := range fileNames {
+		if az.GetPath() != "" && !strings.HasPrefix(path, az.GetPath()) {
+			continue
+		}
+		if slices.Contains(filesExtensions, getFileExtension(path)) {
+			files = append(files, path)
+		}
+
+	}
+	return files, nil
+}
+
+func getFileExtension(path string) string {
+	return strings.TrimPrefix(filepath.Ext(path), ".")
+}

--- a/azureparser/v1/tree_test.go
+++ b/azureparser/v1/tree_test.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestListAllNames(t *testing.T) {
+	{
+		az, err := NewAzureParserWithURL(urlA)
+		assert.NoError(t, err)
+		tree, err := az.ListAllNames()
+		assert.NoError(t, err)
+		assert.Equal(t, 1440, len(tree))
+	}
+}
+
+func TestGetFileExtension(t *testing.T) {
+	assert.Equal(t, "yaml", getFileExtension("my/name.yaml"))
+	assert.Equal(t, "txt", getFileExtension("/my/name.txt"))
+	assert.Equal(t, "json", getFileExtension("myName.json"))
+	assert.Equal(t, "", getFileExtension("myName"))
+}

--- a/init.go
+++ b/init.go
@@ -5,6 +5,7 @@ import (
 
 	giturl "github.com/whilp/git-urls"
 
+	"github.com/kubescape/go-git-url/apis/azureapi"
 	"github.com/kubescape/go-git-url/apis/githubapi"
 	"github.com/kubescape/go-git-url/apis/gitlabapi"
 	azureparserv1 "github.com/kubescape/go-git-url/azureparser/v1"
@@ -43,6 +44,8 @@ func NewGitAPI(fullURL string) (IGitAPI, error) {
 		return githubparserv1.NewGitHubParserWithURL(fullURL)
 	case gitlabapi.DEFAULT_HOST:
 		return gitlabparserv1.NewGitLabParserWithURL(fullURL)
+	case azureapi.DEFAULT_HOST, azureapi.DEV_HOST:
+		return azureparserv1.NewAzureParserWithURL(fullURL)
 	default:
 		return nil, fmt.Errorf("repository host '%s' not supported", hostUrl)
 	}


### PR DESCRIPTION
Signed-off-by: Anubhav Gupta <mail.anubhav06@gmail.com>

**Added support for Azure's API**
Supported format: `https://<>@dev.azure.com/<>/<>/_git/<>`
Example: `https://anubhav06@dev.azure.com/anubhav06/testing/_git/testing`

For private repo scanning, we need to add the Personal Access Token in the `AZURE_TOKEN` env

The following example shows the working of this Azure API support:
![0](https://user-images.githubusercontent.com/43821031/210243862-eb3ebff5-6d5b-46c6-a884-7ebf26c9e2f1.png)
