### PR TITLE
fix azure public and ssh scans

### DIFF
--- a/apis/azureapi/apis.go
+++ b/apis/azureapi/apis.go
@@ -12,6 +12,7 @@ import (
 const (
 	DEFAULT_HOST string = "azure.com"
 	DEV_HOST     string = "dev.azure.com"
+	SSH_DEV_HOST string = "ssh.dev.azure.com"
 )
 
 type IAzureAPI interface {

--- a/azureparser/v1/parser.go
+++ b/azureparser/v1/parser.go
@@ -56,7 +56,7 @@ func (az *AzureURL) GetRepoName() string    { return az.repo }
 func (az *AzureURL) GetPath() string        { return az.path }
 func (az *AzureURL) GetToken() string       { return az.token }
 func (az *AzureURL) GetHttpCloneURL() string {
-	return fmt.Sprintf("https://%s@%s/%s/%s/_git/%s", az.GetOwnerName(), az.GetHostName(), az.GetOwnerName(), az.GetProjectName(), az.GetRepoName())
+	return fmt.Sprintf("https://%s/%s/%s/_git/%s", az.GetHostName(), az.GetOwnerName(), az.GetProjectName(), az.GetRepoName())
 }
 
 func (az *AzureURL) SetOwnerName(o string)         { az.owner = o }

--- a/azureparser/v1/parser_test.go
+++ b/azureparser/v1/parser_test.go
@@ -13,6 +13,10 @@ var (
 	urlD = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=/scripts&version=GTv1.0.1&_a=contents"
 	urlE = "https://dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public?path=%2F&version=GBdev"
 	urlF = "https://dwertent@dev.azure.com/dwertent/ks-testing-public/_git/ks-testing-public"
+	// scp-like syntax supported by git for ssh
+	// see: https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-clone.html#URLS
+	// regular form
+	urlG = "git@ssh.dev.azure.com:v3/dwertent/ks-testing-public/ks-testing-public"
 )
 
 func TestNewAzureParserWithURL(t *testing.T) {
@@ -62,8 +66,42 @@ func TestNewAzureParserWithURL(t *testing.T) {
 		assert.Equal(t, "", az.GetBranchName())
 		assert.Equal(t, "/scripts", az.GetPath())
 	}
+	{
+		az, err := NewAzureParserWithURL(urlE)
+		assert.NoError(t, err)
+		assert.Equal(t, "dev.azure.com", az.GetHostName())
+		assert.Equal(t, "azure", az.GetProvider())
+		assert.Equal(t, "dwertent", az.GetOwnerName())
+		assert.Equal(t, "ks-testing-public", az.GetRepoName())
+		assert.Equal(t, urlA, az.GetURL().String())
+		assert.Equal(t, "", az.GetTag())
+		assert.Equal(t, "dev", az.GetBranchName())
+		assert.Equal(t, "/", az.GetPath())
+	}
+	{
+		az, err := NewAzureParserWithURL(urlF)
+		assert.NoError(t, err)
+		assert.Equal(t, "dev.azure.com", az.GetHostName())
+		assert.Equal(t, "azure", az.GetProvider())
+		assert.Equal(t, "dwertent", az.GetOwnerName())
+		assert.Equal(t, "ks-testing-public", az.GetRepoName())
+		assert.Equal(t, urlA, az.GetURL().String())
+		assert.Equal(t, "", az.GetBranchName())
+		assert.Equal(t, "", az.GetPath())
+	}
+	{
+		az, err := NewAzureParserWithURL(urlG)
+		assert.NoError(t, err)
+		assert.NoError(t, err)
+		assert.Equal(t, "dev.azure.com", az.GetHostName())
+		assert.Equal(t, "azure", az.GetProvider())
+		assert.Equal(t, "dwertent", az.GetOwnerName())
+		assert.Equal(t, "ks-testing-public", az.GetRepoName())
+		assert.Equal(t, urlA, az.GetURL().String())
+		assert.Equal(t, "", az.GetBranchName())
+		assert.Equal(t, "", az.GetPath())
+	}
 }
-
 
 func TestSetDefaultBranch(t *testing.T) {
 	{

--- a/init.go
+++ b/init.go
@@ -49,7 +49,7 @@ func NewGitAPI(fullURL string) (IGitAPI, error) {
 		return githubparserv1.NewGitHubParserWithURL(fullURL)
 	case gitlabapi.DEFAULT_HOST:
 		return gitlabparserv1.NewGitLabParserWithURL(fullURL)
-	case azureapi.DEFAULT_HOST, azureapi.DEV_HOST:
+	case azureapi.DEFAULT_HOST, azureapi.DEV_HOST, azureapi.SSH_DEV_HOST:
 		return azureparserv1.NewAzureParserWithURL(fullURL)
 	case bitbucketapi.DEFAULT_HOST:
 		return bitbucketparserv1.NewBitBucketParserWithURL(fullURL)


### PR DESCRIPTION
- `httpCloneURL` should not include `@user` otherwise azure asks for authentication, even for public repos
- added ssh host to supported hosts