### PR TITLE
add github support for www subdomain

### DIFF
--- a/apis/githubapi/apis.go
+++ b/apis/githubapi/apis.go
@@ -9,8 +9,9 @@ import (
 )
 
 const (
-	DEFAULT_HOST string = "github.com"
-	RAW_HOST     string = "raw.githubusercontent.com"
+	DEFAULT_HOST   string = "github.com"
+	RAW_HOST       string = "raw.githubusercontent.com"
+	SUBDOMAIN_HOST string = "www.github.com"
 )
 
 type IGitHubAPI interface {

--- a/githubparser/v1/parser.go
+++ b/githubparser/v1/parser.go
@@ -40,7 +40,7 @@ func (gh *GitHubURL) GetURL() *url.URL {
 	}
 }
 func IsHostGitHub(host string) bool {
-	return host == githubapi.DEFAULT_HOST || host == githubapi.RAW_HOST
+	return host == githubapi.DEFAULT_HOST || host == githubapi.RAW_HOST || host == githubapi.SUBDOMAIN_HOST
 }
 
 func (gh *GitHubURL) GetProvider() string   { return apis.ProviderGitHub.String() }

--- a/githubparser/v1/parser_test.go
+++ b/githubparser/v1/parser_test.go
@@ -14,6 +14,7 @@ var (
 	urlD = "https://raw.githubusercontent.com/kubescape/go-git-url/master/files/file0.json"
 	urlE = "git@github.com:kubescape/go-git-url.git"
 	urlF = "git@github.com:foobar/kubescape/go-git-url.git"
+	urlG = "https://www.github.com/kubescape/go-git-url"
 )
 
 func TestNewGitHubParserWithURL(t *testing.T) {
@@ -73,6 +74,16 @@ func TestNewGitHubParserWithURL(t *testing.T) {
 			_, _ = NewGitHubParserWithURL(urlF)
 		})
 	}
+	{
+		gh, err := NewGitHubParserWithURL(urlG)
+		assert.NoError(t, err)
+		assert.Equal(t, "github.com", gh.GetHostName())
+		assert.Equal(t, "kubescape", gh.GetOwnerName())
+		assert.Equal(t, "go-git-url", gh.GetRepoName())
+		assert.Equal(t, urlA, gh.GetURL().String())
+		assert.Equal(t, "", gh.GetBranchName())
+		assert.Equal(t, "", gh.GetPath())
+	}
 }
 
 func TestSetDefaultBranch(t *testing.T) {
@@ -90,6 +101,12 @@ func TestSetDefaultBranch(t *testing.T) {
 	}
 	{
 		gh, err := NewGitHubParserWithURL(urlE)
+		assert.NoError(t, err)
+		assert.NoError(t, gh.SetDefaultBranchName())
+		assert.Equal(t, "master", gh.GetBranchName())
+	}
+	{
+		gh, err := NewGitHubParserWithURL(urlG)
 		assert.NoError(t, err)
 		assert.NoError(t, gh.SetDefaultBranchName())
 		assert.Equal(t, "master", gh.GetBranchName())

--- a/init.go
+++ b/init.go
@@ -45,7 +45,7 @@ func NewGitAPI(fullURL string) (IGitAPI, error) {
 	}
 
 	switch hostUrl {
-	case githubapi.DEFAULT_HOST, githubapi.RAW_HOST:
+	case githubapi.DEFAULT_HOST, githubapi.RAW_HOST, githubapi.SUBDOMAIN_HOST:
 		return githubparserv1.NewGitHubParserWithURL(fullURL)
 	case gitlabapi.DEFAULT_HOST:
 		return gitlabparserv1.NewGitLabParserWithURL(fullURL)

--- a/init_test.go
+++ b/init_test.go
@@ -18,6 +18,16 @@ func TestNewGitURL(t *testing.T) {
 		assert.Equal(t, githubURL, gh.GetURL().String())
 	}
 	{ // parse github
+		const githubURL = "https://www.github.com/kubescape/go-git-url"
+		gh, err := NewGitURL(githubURL)
+		assert.NoError(t, err)
+		assert.Equal(t, "github", gh.GetProvider())
+		assert.Equal(t, "kubescape", gh.GetOwnerName())
+		assert.Equal(t, "go-git-url", gh.GetRepoName())
+		assert.Equal(t, "", gh.GetBranchName())
+		assert.Equal(t, "https://github.com/kubescape/go-git-url", gh.GetURL().String())
+	}
+	{ // parse github
 		const githubURL = "git@github.com:kubescape/go-git-url.git"
 		gh, err := NewGitURL(githubURL)
 		assert.NoError(t, err)


### PR DESCRIPTION
Fixes #10 

**About the changes**
Added support for "www" subdomain hostname for github.

**Before**
![0](https://user-images.githubusercontent.com/43821031/236506381-335a16d2-6b6c-4227-a836-4c47f73e7a62.png)
**Now**
![1](https://user-images.githubusercontent.com/43821031/236506401-bd40a862-6d9d-475f-978f-be9d835cfc68.png)

After this PR is merged, I'll open a new PR in [kubescape/kubescape](https://github.com/kubescape/kubescape) to update the version of kubescape/go-git-url in its `go.mod` file
