### PR TITLE
replace whilp/git-urls module by chainguard-dev/git-urls

### DIFF
--- a/azureparser/v1/parser.go
+++ b/azureparser/v1/parser.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
+	giturl "github.com/chainguard-dev/git-urls"
 	"github.com/kubescape/go-git-url/apis"
 	"github.com/kubescape/go-git-url/apis/azureapi"
-	giturl "github.com/whilp/git-urls"
 )
 
 const HOST = "azure.com"

--- a/bitbucketparser/v1/parser.go
+++ b/bitbucketparser/v1/parser.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
+	giturl "github.com/chainguard-dev/git-urls"
 	"github.com/kubescape/go-git-url/apis"
 	"github.com/kubescape/go-git-url/apis/bitbucketapi"
-	giturl "github.com/whilp/git-urls"
 )
 
 const HOST = "bitbucket.org"

--- a/githubparser/v1/parser.go
+++ b/githubparser/v1/parser.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
+	giturl "github.com/chainguard-dev/git-urls"
 	"github.com/kubescape/go-git-url/apis"
 	"github.com/kubescape/go-git-url/apis/githubapi"
-	giturl "github.com/whilp/git-urls"
 )
 
 // NewGitHubParser empty instance of a github parser

--- a/gitlabparser/v1/parser.go
+++ b/gitlabparser/v1/parser.go
@@ -6,9 +6,9 @@ import (
 	"os"
 	"strings"
 
+	giturl "github.com/chainguard-dev/git-urls"
 	"github.com/kubescape/go-git-url/apis"
 	"github.com/kubescape/go-git-url/apis/gitlabapi"
-	giturl "github.com/whilp/git-urls"
 )
 
 const HOST = "gitlab.com"

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/kubescape/go-git-url
 go 1.19
 
 require (
+	github.com/chainguard-dev/git-urls v1.0.2
 	github.com/stretchr/testify v1.3.0
-	github.com/whilp/git-urls v1.0.0
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/chainguard-dev/git-urls v1.0.2 h1:pSpT7ifrpc5X55n4aTTm7FFUE+ZQHKiqpiwNkJrVcKQ=
+github.com/chainguard-dev/git-urls v1.0.2/go.mod h1:rbGgj10OS7UgZlbzdUQIQpT0k/D4+An04HJY7Ol+Y/o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -8,8 +10,6 @@ github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTd
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/whilp/git-urls v1.0.0 h1:95f6UMWN5FKW71ECsXRUd3FVYiXdrE7aX4NZKcPmIjU=
-github.com/whilp/git-urls v1.0.0/go.mod h1:J16SAmobsqc3Qcy98brfl5f5+e0clUvg1krgwk/qCfE=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 k8s.io/klog/v2 v2.0.0/go.mod h1:PBfzABfn139FHAV07az/IF9Wp1bkk3vpT2XSJ76fSDE=
 k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=

--- a/init.go
+++ b/init.go
@@ -3,7 +3,7 @@ package giturl
 import (
 	"fmt"
 
-	giturl "github.com/whilp/git-urls"
+	giturl "github.com/chainguard-dev/git-urls"
 
 	"github.com/kubescape/go-git-url/apis/azureapi"
 	"github.com/kubescape/go-git-url/apis/bitbucketapi"


### PR DESCRIPTION
We discovered a vulnerability on the module github.com/whilp/git-urls [GHSA-3f2q-6294-fmq5](https://github.com/advisories/GHSA-3f2q-6294-fmq5). This repository doesn't look to be maintained at this moment. That is why we decided to fix the vulnerability and move the repository over our organization. We plan to maintain this repository in the future.